### PR TITLE
manifest: Add arduino-core build snippet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,15 +50,15 @@ jobs:
 
       - name: Build fade
         run: |
-          west build -p -b arduino_nano_33_ble/nrf52840/sense $MODULE_PATH/samples/fade
+          west build -p -S arduino-core -b arduino_nano_33_ble/nrf52840/sense $MODULE_PATH/samples/fade
 
       - name: Build i2cdemo
         run: |
-          west build -p -b arduino_nano_33_ble/nrf52840/sense $MODULE_PATH/samples/i2cdemo
+          west build -p -S arduino-core -b arduino_nano_33_ble/nrf52840/sense $MODULE_PATH/samples/i2cdemo
 
       - name: Build adc
         run: |
-          west build -p -b beagleconnect_freedom@C7/cc1352p7 $MODULE_PATH/samples/analog_input
+          west build -p -S arduino-core -b beagleconnect_freedom@C7/cc1352p7 $MODULE_PATH/samples/analog_input
 
       - name: Archive firmware
         uses: actions/upload-artifact@v4

--- a/samples/analog_input/CMakeLists.txt
+++ b/samples/analog_input/CMakeLists.txt
@@ -2,25 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-# get value of NORMALIZED_BOARD_TARGET early
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS yaml boards)
-
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-endif()
-
-if (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-elseif (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-elseif (EXISTS ${variant_dir}/${BOARD}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${BOARD}.overlay)
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(analog_input)
 

--- a/samples/analog_input/README.rst
+++ b/samples/analog_input/README.rst
@@ -18,7 +18,7 @@ Building and Running
 Build and flash analog_input sample as follows,
 
 ```sh
-$> west build -p -b arduino_nano_33_ble sample/analog_input/
+$> west build -p -S arduino-core -b arduino_nano_33_ble samples/analog_input/
 
 $> west flash --bossac=/home/$USER/.arduino15/packages/arduino/tools/bossac/1.9.1-arduino2/bossac
 ```

--- a/samples/attach_interrupt/CMakeLists.txt
+++ b/samples/attach_interrupt/CMakeLists.txt
@@ -2,25 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-# get value of NORMALIZED_BOARD_TARGET early
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS yaml boards)
-
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-endif()
-
-if (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-elseif (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-elseif (EXISTS ${variant_dir}/${BOARD}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${BOARD}.overlay)
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(attach_interrupt)
 

--- a/samples/attach_interrupt/README.rst
+++ b/samples/attach_interrupt/README.rst
@@ -14,7 +14,7 @@ Building and Running
 Build and flash attachInterrupt sample as follows,
 
 ```sh
-$> west build  -p -b arduino_nano_33_ble samples/basic/attach_interrupt/ -DZEPHYR_EXTRA_MODULES=/home/$USER/zephyrproject/modules/lib/Arduino-Core-Zephyr
+$> west build -p -S arduino-core -b arduino_nano_33_ble samples/basic/attach_interrupt/
 
 $> west flash --bossac=/home/$USER/.arduino15/packages/arduino/tools/bossac/1.9.1-arduino2/bossac
 ```

--- a/samples/blinky_arduino/CMakeLists.txt
+++ b/samples/blinky_arduino/CMakeLists.txt
@@ -2,25 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-# get value of NORMALIZED_BOARD_TARGET early
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS yaml boards)
-
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-endif()
-
-if (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-elseif (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-elseif (EXISTS ${variant_dir}/${BOARD}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${BOARD}.overlay)
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(blinky)
 

--- a/samples/blinky_arduino/README.rst
+++ b/samples/blinky_arduino/README.rst
@@ -23,7 +23,7 @@ Building and Running
 Build and flash Blinky as follows,
 
 ```sh
-$> west build  -p -b arduino_nano_33_ble samples/blinky_arduino/ -DZEPHYR_EXTRA_MODULES=/home/$USER/zephyrproject/modules/lib/Arduino-Core-Zephyr
+$> west build -p -S arduino-core -b arduino_nano_33_ble samples/blinky_arduino/
 
 $> west flash --bossac=/home/$USER/.arduino15/packages/arduino/tools/bossac/1.9.1-arduino2/bossac
 ```

--- a/samples/button_press_led/CMakeLists.txt
+++ b/samples/button_press_led/CMakeLists.txt
@@ -2,25 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-# get value of NORMALIZED_BOARD_TARGET early
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS yaml boards)
-
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-endif()
-
-if (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-elseif (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-elseif (EXISTS ${variant_dir}/${BOARD}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${BOARD}.overlay)
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(button_press_led)
 

--- a/samples/button_press_led/README.rst
+++ b/samples/button_press_led/README.rst
@@ -22,7 +22,7 @@ Building and Running
 Build and flash as follows,
 
 ```sh
-$> west build  -p -b arduino_nano_33_ble samples/button_press_led -DZEPHYR_EXTRA_MODULES=/home/$USER/zephyrproject/modules/lib/Arduino-Core-Zephyr
+$> west build -p -S arduino-core -b arduino_nano_33_ble samples/button_press_led
 
 $> west flash --bossac=/home/$USER/.arduino15/packages/arduino/tools/bossac/1.9.1-arduino2/bossac
 ```

--- a/samples/fade/CMakeLists.txt
+++ b/samples/fade/CMakeLists.txt
@@ -2,25 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-# get value of NORMALIZED_BOARD_TARGET early
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS yaml boards)
-
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-endif()
-
-if (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-elseif (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-elseif (EXISTS ${variant_dir}/${BOARD}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${BOARD}.overlay)
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fade)
 

--- a/samples/fade/README.rst
+++ b/samples/fade/README.rst
@@ -15,7 +15,7 @@ Building and Running
 Build and flash Fade sample as follows,
 
 ```sh
-$> west build  -p -b arduino_nano_33_ble samples/basic/fade/ -DZEPHYR_EXTRA_MODULES=/home/$USER/zephyrproject/modules/lib/Arduino-Core-Zephyr
+$> west build -p -S arduino-core -b arduino_nano_33_ble samples/basic/fade/
 
 $> west flash --bossac=/home/$USER/.arduino15/packages/arduino/tools/bossac/1.9.1-arduino2/bossac
 ```

--- a/samples/hello_arduino/CMakeLists.txt
+++ b/samples/hello_arduino/CMakeLists.txt
@@ -2,25 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-# get value of NORMALIZED_BOARD_TARGET early
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS yaml boards)
-
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-endif()
-
-if (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-elseif (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-elseif (EXISTS ${variant_dir}/${BOARD}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${BOARD}.overlay)
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hello_world)
 

--- a/samples/hello_arduino/README.rst
+++ b/samples/hello_arduino/README.rst
@@ -18,6 +18,7 @@ This application can be built and executed on QEMU as follows:
    :zephyr-app: samples/hello_world
    :host-os: unix
    :board: qemu_x86
+   :snippets: arduino-core
    :goals: run
    :compact:
 

--- a/samples/i2cdemo/CMakeLists.txt
+++ b/samples/i2cdemo/CMakeLists.txt
@@ -2,25 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-# get value of NORMALIZED_BOARD_TARGET early
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS yaml boards)
-
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-endif()
-
-if (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-elseif (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-elseif (EXISTS ${variant_dir}/${BOARD}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${BOARD}.overlay)
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(i2cdemo)
 

--- a/samples/i2cdemo/README.rst
+++ b/samples/i2cdemo/README.rst
@@ -20,7 +20,7 @@ Building and Running
 Build and flash Blinky as follows,
 
 ```sh
-$> west build -p -b arduino_nano_33_ble samples/i2cdemo
+$> west build -p -S arduino-core -b arduino_nano_33_ble samples/i2cdemo
 
 $> west flash --bossac=/home/$USER/.arduino15/packages/arduino/tools/bossac/1.9.1-arduino2/bossac
 ```

--- a/samples/serial_event/CMakeLists.txt
+++ b/samples/serial_event/CMakeLists.txt
@@ -2,25 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-# get value of NORMALIZED_BOARD_TARGET early
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS yaml boards)
-
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-endif()
-
-if (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-elseif (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-elseif (EXISTS ${variant_dir}/${BOARD}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${BOARD}.overlay)
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(serial_event)
 

--- a/samples/serial_event/README.rst
+++ b/samples/serial_event/README.rst
@@ -14,7 +14,7 @@ Building and Running
 Build and flash serial_event sample as follows,
 
 ```sh
-$> west build -p -b arduino_nano_33_ble sample/serial_event/
+$> west build -p -S arduino-core -b arduino_nano_33_ble samples/serial_event/
 
 $> west flash --bossac=/home/$USER/.arduino15/packages/arduino/tools/bossac/1.9.1-arduino2/bossac
 ```

--- a/samples/spi_controller/CMakeLists.txt
+++ b/samples/spi_controller/CMakeLists.txt
@@ -2,25 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-# get value of NORMALIZED_BOARD_TARGET early
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS yaml boards)
-
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-endif()
-
-if (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-elseif (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-elseif (EXISTS ${variant_dir}/${BOARD}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${BOARD}.overlay)
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(spi_controller)
 

--- a/samples/threads_arduino/CMakeLists.txt
+++ b/samples/threads_arduino/CMakeLists.txt
@@ -2,25 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-# get value of NORMALIZED_BOARD_TARGET early
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS yaml boards)
-
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-endif()
-
-if (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-elseif (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-elseif (EXISTS ${variant_dir}/${BOARD}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${BOARD}.overlay)
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(threads)
 

--- a/samples/threads_arduino/README.rst
+++ b/samples/threads_arduino/README.rst
@@ -41,6 +41,7 @@ For example, to build this sample for :ref:`arduino_nano_33_ble`:
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/arduino-threads
    :board: arduino_nano_33_ble
+   :snippets: arduino-core
    :goals: build flash
    :compact:
 

--- a/samples/tone_doremi/CMakeLists.txt
+++ b/samples/tone_doremi/CMakeLists.txt
@@ -2,25 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-# get value of NORMALIZED_BOARD_TARGET early
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS yaml boards)
-
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${NORMALIZED_BOARD_TARGET})
-elseif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-  set(variant_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../variants/${BOARD})
-endif()
-
-if (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}_${BOARD_REVISION}.overlay)
-elseif (EXISTS ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${NORMALIZED_BOARD_TARGET}.overlay)
-elseif (EXISTS ${variant_dir}/${BOARD}.overlay)
-  set(DTC_OVERLAY_FILE ${variant_dir}/${BOARD}.overlay)
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tone_doremi)
 

--- a/variants/arduino_mkrzero/arduino_mkrzero.conf
+++ b/variants/arduino_mkrzero/arduino_mkrzero.conf
@@ -1,0 +1,2 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0

--- a/variants/arduino_nano_33_ble/arduino_nano_33_ble.conf
+++ b/variants/arduino_nano_33_ble/arduino_nano_33_ble.conf
@@ -1,0 +1,2 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0

--- a/variants/arduino_nano_33_ble_nrf52840_sense/arduino_nano_33_ble_nrf52840_sense.conf
+++ b/variants/arduino_nano_33_ble_nrf52840_sense/arduino_nano_33_ble_nrf52840_sense.conf
@@ -1,0 +1,2 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0

--- a/variants/arduino_nano_33_iot/arduino_nano_33_iot.conf
+++ b/variants/arduino_nano_33_iot/arduino_nano_33_iot.conf
@@ -1,0 +1,2 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0

--- a/variants/beagleconnect_freedom/beagleconnect_freedom.conf
+++ b/variants/beagleconnect_freedom/beagleconnect_freedom.conf
@@ -1,0 +1,2 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0

--- a/variants/cc3220sf_launchxl/cc3220sf_launchxl.conf
+++ b/variants/cc3220sf_launchxl/cc3220sf_launchxl.conf
@@ -1,0 +1,2 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0

--- a/variants/native_sim/native_sim.conf
+++ b/variants/native_sim/native_sim.conf
@@ -1,0 +1,2 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0

--- a/variants/nrf52840dk_nrf52840/nrf52840dk_nrf52840.conf
+++ b/variants/nrf52840dk_nrf52840/nrf52840dk_nrf52840.conf
@@ -1,0 +1,2 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0

--- a/variants/nrf9160dk_nrf9160/nrf9160dk_nrf9160.conf
+++ b/variants/nrf9160dk_nrf9160/nrf9160dk_nrf9160.conf
@@ -1,0 +1,2 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0

--- a/variants/pocketbeagle_2_am6254_a53/pocketbeagle_2_am6254_a53.conf
+++ b/variants/pocketbeagle_2_am6254_a53/pocketbeagle_2_am6254_a53.conf
@@ -1,0 +1,2 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0

--- a/variants/rpi_pico/rpi_pico.conf
+++ b/variants/rpi_pico/rpi_pico.conf
@@ -1,0 +1,2 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -3,6 +3,8 @@ name: arduinocore-zephyr
 build:
   cmake: .
   kconfig: Kconfig
+  settings:
+    snippet_root: zephyr
 samples:
   - samples
 blobs:

--- a/zephyr/snippets/arduino-core/README.rst
+++ b/zephyr/snippets/arduino-core/README.rst
@@ -1,0 +1,17 @@
+.. _arduino_core_snippet:
+
+Arduino-Core configuration enabling snippet
+###########################################
+
+Overview
+********
+
+.. code-block:: console
+
+    west build -S arduino-core ...
+
+
+This snippet enables the configuration required for each board to build ArduinoCore.
+The actual configuration files are located under the ``variants``
+directory of the ArduinoCore-zephyr module.
+

--- a/zephyr/snippets/arduino-core/arduino-core.conf
+++ b/zephyr/snippets/arduino-core/arduino-core.conf
@@ -1,0 +1,4 @@
+# Copyright (c) Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ARDUINO_API=y

--- a/zephyr/snippets/arduino-core/snippet.yml
+++ b/zephyr/snippets/arduino-core/snippet.yml
@@ -1,0 +1,97 @@
+name: arduino-core
+append:
+  EXTRA_CONF_FILE: arduino-core.conf
+
+boards:
+  #arduino_giga_r1/stm32h747xx/m7:
+  #  append:
+  #    EXTRA_CONF_FILE: ../../../variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.conf
+  #    EXTRA_DTC_OVERLAY_FILE: ../../../variants/arduino_giga_r1_stm32h747xx_m7/arduino_giga_r1_stm32h747xx_m7.overlay
+  arduino_mkrzero/samd21g18a:
+    append:
+      EXTRA_CONF_FILE: ../../../variants/arduino_mkrzero/arduino_mkrzero.conf
+      EXTRA_DTC_OVERLAY_FILE: ../../../variants/arduino_mkrzero/arduino_mkrzero.overlay
+  arduino_nano_33_ble/nrf52840:
+    append:
+      EXTRA_CONF_FILE: ../../../variants/arduino_nano_33_ble/arduino_nano_33_ble.conf
+      EXTRA_DTC_OVERLAY_FILE: ../../../variants/arduino_nano_33_ble/arduino_nano_33_ble.overlay
+  arduino_nano_33_ble/nrf52840/sense:
+    append:
+      EXTRA_CONF_FILE: ../../../variants/arduino_nano_33_ble_nrf52840_sense/arduino_nano_33_ble_nrf52840_sense.conf
+      EXTRA_DTC_OVERLAY_FILE: ../../../variants/arduino_nano_33_ble_nrf52840_sense/arduino_nano_33_ble_nrf52840_sense.overlay
+  arduino_nano_33_iot/samd21g18a:
+    append:
+      EXTRA_CONF_FILE: ../../../variants/arduino_nano_33_iot/arduino_nano_33_iot.conf
+      EXTRA_DTC_OVERLAY_FILE: ../../../variants/arduino_nano_33_iot/arduino_nano_33_iot.overlay
+  #arduino_nano_connect/rp2040:
+  #  append:
+  #    EXTRA_CONF_FILE: ../../../variants/arduino_nano_connect_rp2040/arduino_nano_connect_rp2040.conf
+  #    EXTRA_DTC_OVERLAY_FILE: ../../../variants/arduino_nano_connect_rp2040/arduino_nano_connect_rp2040.overlay
+  #arduino_nano_matter/mgm240sd22vna:
+  #  append:
+  #    EXTRA_CONF_FILE: ../../../variants/arduino_nano_matter_mgm240sd22vna/arduino_nano_matter_mgm240sd22vna.conf
+  #    EXTRA_DTC_OVERLAY_FILE: ../../../variants/arduino_nano_matter_mgm240sd22vna/arduino_nano_matter_mgm240sd22vna.overlay
+  #arduino_nicla_sense_me/nrf52832:
+  #  append:
+  #    EXTRA_CONF_FILE: ../../../variants/arduino_nicla_sense_me_nrf52832/arduino_nicla_sense_me_nrf52832.conf
+  #    EXTRA_DTC_OVERLAY_FILE: ../../../variants/arduino_nicla_sense_me_nrf52832/arduino_nicla_sense_me_nrf52832.overlay
+  #arduino_nicla_vision/stm32h747xx/m7:
+  #  append:
+  #    EXTRA_CONF_FILE: ../../../variants/arduino_nicla_vision_stm32h747xx_m7/arduino_nicla_vision_stm32h747xx_m7.conf
+  #    EXTRA_DTC_OVERLAY_FILE: ../../../variants/arduino_nicla_vision_stm32h747xx_m7/arduino_nicla_vision_stm32h747xx_m7.overlay
+  #arduino_opta/stm32h747xx/m7:
+  #  append:
+  #    EXTRA_CONF_FILE: ../../../variants/arduino_opta_stm32h747xx_m7/arduino_opta_stm32h747xx_m7.conf
+  #    EXTRA_DTC_OVERLAY_FILE: ../../../variants/arduino_opta_stm32h747xx_m7/arduino_opta_stm32h747xx_m7.overlay
+  #arduino_portenta_c33/r7fa6m5bh3cfc:
+  #  append:
+  #    EXTRA_CONF_FILE: ../../../variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.conf
+  #    EXTRA_DTC_OVERLAY_FILE: ../../../variants/arduino_portenta_c33_r7fa6m5bh3cfc/arduino_portenta_c33_r7fa6m5bh3cfc.overlay
+  #arduino_portenta_h7/stm32h747xx/m7:
+  #  append:
+  #    EXTRA_CONF_FILE: ../../../variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.conf
+  #    EXTRA_DTC_OVERLAY_FILE: ../../../variants/arduino_portenta_h7_stm32h747xx_m7/arduino_portenta_h7_stm32h747xx_m7.overlay
+  #arduino_uno_q/stm32u585xx:
+  #  append:
+  #    EXTRA_CONF_FILE: ../../../variants/arduino_uno_q_stm32u585xx/arduino_uno_q_stm32u585xx.conf
+  #    EXTRA_DTC_OVERLAY_FILE: ../../../variants/arduino_uno_q_stm32u585xx/arduino_uno_q_stm32u585xx.overlay
+  beagleconnect_freedom/cc1352p7:
+    append:
+      EXTRA_CONF_FILE: ../../../variants/beagleconnect_freedom/beagleconnect_freedom.conf
+      EXTRA_DTC_OVERLAY_FILE: ../../../variants/beagleconnect_freedom/beagleconnect_freedom.overlay
+  cc3220sf_launchxl/cc3220sf:
+    append:
+      EXTRA_CONF_FILE: ../../../variants/cc3220sf_launchxl/cc3220sf_launchxl.conf
+      EXTRA_DTC_OVERLAY_FILE: ../../../variants/cc3220sf_launchxl/cc3220sf_launchxl.overlay
+  #ek_ra8d1/r7fa8d1bhecbd:
+  #  append:
+  #    EXTRA_CONF_FILE: ../../../variants/ek_ra8d1_r7fa8d1bhecbd/ek_ra8d1_r7fa8d1bhecbd.conf
+  #    EXTRA_DTC_OVERLAY_FILE: ../../../variants/ek_ra8d1_r7fa8d1bhecbd/ek_ra8d1_r7fa8d1bhecbd.overlay
+  #frdm_mcxn947/mcxn947/cpu0:
+  #  append:
+  #    EXTRA_CONF_FILE: ../../../variants/frdm_mcxn947_mcxn947_cpu0/frdm_mcxn947_mcxn947_cpu0.conf
+  #    EXTRA_DTC_OVERLAY_FILE: ../../../variants/frdm_mcxn947_mcxn947_cpu0/frdm_mcxn947_mcxn947_cpu0.overlay
+  #frdm_rw612/rw612:
+  #  append:
+  #    EXTRA_CONF_FILE: ../../../variants/frdm_rw612_rw612/frdm_rw612_rw612.conf
+  #    EXTRA_DTC_OVERLAY_FILE: ../../../variants/frdm_rw612_rw612/frdm_rw612_rw612.overlay
+  native_sim/native:
+    append:
+      EXTRA_CONF_FILE: ../../../variants/native_sim/native_sim.conf
+      EXTRA_DTC_OVERLAY_FILE: ../../../variants/native_sim/native_sim.overlay
+  nrf52840dk/nrf52840:
+    append:
+      EXTRA_CONF_FILE: ../../../variants/nrf52840dk_nrf52840/nrf52840dk_nrf52840.conf
+      EXTRA_DTC_OVERLAY_FILE: ../../../variants/nrf52840dk_nrf52840/nrf52840dk_nrf52840.overlay
+  nrf9160dk/nrf9160:
+    append:
+      EXTRA_CONF_FILE: ../../../variants/nrf9160dk_nrf9160/nrf9160dk_nrf9160.conf
+      EXTRA_DTC_OVERLAY_FILE: ../../../variants/nrf9160dk_nrf9160/nrf9160dk_nrf9160.overlay
+  pocketbeagle_2/am6254/a53:
+    append:
+      EXTRA_CONF_FILE: ../../../variants/pocketbeagle_2_am6254_a53/pocketbeagle_2_am6254_a53.conf
+      EXTRA_DTC_OVERLAY_FILE: ../../../variants/pocketbeagle_2_am6254_a53/pocketbeagle_2_am6254_a53.overlay
+  rpi_pico/rp2040:
+    append:
+      EXTRA_CONF_FILE: ../../../variants/rpi_pico/rpi_pico.conf
+      EXTRA_DTC_OVERLAY_FILE: ../../../variants/rpi_pico/rpi_pico.overlay


### PR DESCRIPTION
Added an arduino-core Zephyr snippet that applies the common ArduinoCore config.
This snippet able to eliminate special handling *.overlay and *.conf.