### PR TITLE
core: arduino: add common files for compatibility

### DIFF
--- a/cores/arduino/pins_arduino.h
+++ b/cores/arduino/pins_arduino.h
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2026 KurtE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* empty header file, for libraries which try to include like Adafruit_GFX_Library  */


### PR DESCRIPTION
add empty files:
pins_arduino.h

resolves: #393

Also mentioned in a pull request against one of the Adafruit libraries: https://github.com/adafruit/Adafruit_ILI9341/pull/103 Which has not been touched for several months.