### PR TITLE
feat: import postvariant.h if it exists

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -166,4 +166,8 @@ void analogWriteResolution(int bits);
 // Allow namespace-less operations if Arduino.h is included
 using namespace arduino;
 
+#if __has_include("postvariant.h")
+#include "postvariant.h"
+#endif
+
 #endif // __cplusplus


### PR DESCRIPTION
This commit adds a conditional include for "postvariant.h" in the Arduino.h header file. If it exists, it will be included after the main Arduino definitions. This allows for additional variant-specific configurations or overrides to be applied without modifying the core Arduino.h file directly.